### PR TITLE
Update numbers to use native methods and attributes

### DIFF
--- a/custom_components/jotul/number.py
+++ b/custom_components/jotul/number.py
@@ -25,10 +25,10 @@ class JotulTargetTemperatureNumber(NumberEntity):
 
     def __init__(self, jotul: Jotul):
         """Initialize the number."""
-        self._attr_max_value = 30
-        self._attr_min_value = 20
-        self._attr_value = None
-        self._attr_step = 1
+        self._attr_native_max_value = 30
+        self._attr_native_min_value = 20
+        self._attr_native_value = None
+        self._attr_native_step = 1
         self._attr_name = f"{jotul.name}_target_temperature"
         self.jotul = jotul
 
@@ -43,7 +43,7 @@ class JotulTargetTemperatureNumber(NumberEntity):
         return "mdi:thermometer"
 
     @property
-    def unit_of_measurement(self) -> str:
+    def native_unit_of_measurement(self) -> str:
         """Return the unit of measurement."""
         return TEMP_CELSIUS
 
@@ -51,11 +51,11 @@ class JotulTargetTemperatureNumber(NumberEntity):
         """Fetch new state data for the number.
         This is the only method that should fetch new data for Home Assistant.
         """
-        self._attr_value = self.jotul.get_target_temperature()
+        self._attr_native_value = self.jotul.get_target_temperature()
     
-    def set_value(self, value: float) -> None:
+    def set_native_value(self, value: float) -> None:
         """Update the current value."""
-        self._attr_value = self.jotul.set_target_temperature(value)
+        self._attr_native_value = self.jotul.set_target_temperature(value)
 
 
 class JotulPowerNumber(NumberEntity):
@@ -63,10 +63,10 @@ class JotulPowerNumber(NumberEntity):
 
     def __init__(self, jotul: Jotul):
         """Initialize the number."""
-        self._attr_max_value = 5
-        self._attr_min_value = 1
-        self._attr_value = None
-        self._attr_step = 1
+        self._attr_native_max_value = 5
+        self._attr_native_min_value = 1
+        self._attr_native_value = None
+        self._attr_native_step = 1
         self._attr_name = f"{jotul.name}_power"
         self.jotul = jotul
 
@@ -84,9 +84,9 @@ class JotulPowerNumber(NumberEntity):
         """Fetch new state data for the number.
         This is the only method that should fetch new data for Home Assistant.
         """
-        self._attr_value = self.jotul.get_power()
+        self._attr_native_value = self.jotul.get_power()
     
-    def set_value(self, value: float) -> None:
+    def set_native_value(self, value: float) -> None:
         """Update the current value."""
-        self._attr_value = self.jotul.set_power(int(value))
+        self._attr_native_value = self.jotul.set_power(int(value))
 


### PR DESCRIPTION
HA has refactored the number class and deprecated and now removed old functions. This updates the methods and attributes according to https://developers.home-assistant.io/blog/2022/06/14/number_entity_refactoring/